### PR TITLE
Build fails when Lintian doesn't pass

### DIFF
--- a/main.js
+++ b/main.js
@@ -216,7 +216,7 @@ async function main() {
             ))
             core.endGroup()
 
-            core.startGroup("Run static analysis")
+            core.startGroup("Run static analysis for architecture: " + targetArchitecture)
             await exec.exec("docker", ["exec", container].concat(
                 [
                     "find",
@@ -227,7 +227,7 @@ async function main() {
                     "-print",
                     "-exec",
                     "lintian"
-                ]).concat(lintianOpts.split(" ")).concat(["{}", ";"]
+                ]).concat(lintianOpts.split(" ")).concat(["{}", "+"]
             ))
             core.endGroup()
         }

--- a/main.js
+++ b/main.js
@@ -244,7 +244,7 @@ async function main() {
                 "-name", `*${version}*.*`,
                 "-type", "f",
                 "-print",
-                "-exec", "mv", "{}", artifactsDirectory, ";"
+                "-exec", "mv", "{}", artifactsDirectory, "+"
             ]
         ))
         core.endGroup()

--- a/main.js
+++ b/main.js
@@ -32,7 +32,7 @@ async function main() {
         // Don't sign anything - no keys provided
         // Don't worry about build dependencies - we have already installed them
         // (Seems to not recognize that some packages are installed)
-        const _defaultDpkgBuildPackageOpts = "-us -uc -d"
+        const _defaultDpkgBuildPackageOpts = "-us -uc -d --post-clean"
         const dpkgBuildPackageOpts = core.getInput("dpkg_buildpackage_opts") || _defaultDpkgBuildPackageOpts
         const lintianOpts = core.getInput("lintian_opts") || ""
 


### PR DESCRIPTION
Closes #2 

- Update `find` args to propagate error code of whatever is called with the `-exec` parameter
- Add `--post-clean` argument to `dpkg-buildpackage` to make sure the environment is clean every time a package is built